### PR TITLE
Timeout for execute function

### DIFF
--- a/src/main/java/me/legrange/mikrotik/ApiConnection.java
+++ b/src/main/java/me/legrange/mikrotik/ApiConnection.java
@@ -84,6 +84,16 @@ public abstract class ApiConnection implements AutoCloseable {
      * @throws me.legrange.mikrotik.MikrotikApiException Thrown if the API encounters an error executing a command.
      */
     public abstract List<Map<String, String>> execute(String cmd) throws MikrotikApiException;
+    
+     /**
+     * execute a command and return a list of results.
+     *
+     * @param cmd Command to execute
+     * @param timeout The connection timeout to use when executing the command.
+     * @return The list of results
+     * @throws me.legrange.mikrotik.MikrotikApiException Thrown if the API encounters an error executing a command.
+     */
+    public abstract List<Map<String, String>> execute(String cmd, int timeout) throws MikrotikApiException;
 
     /**
      * execute a command and attach a result listener to receive it's results.

--- a/src/main/java/me/legrange/mikrotik/impl/ApiConnectionImpl.java
+++ b/src/main/java/me/legrange/mikrotik/impl/ApiConnectionImpl.java
@@ -66,6 +66,11 @@ public final class ApiConnectionImpl extends ApiConnection {
     public List<Map<String, String>> execute(String cmd) throws MikrotikApiException {
         return execute(Parser.parse(cmd), timeout);
     }
+    
+    @Override
+    public List<Map<String, String>> execute(String cmd, int timeout) throws MikrotikApiException {
+        return execute(Parser.parse(cmd), timeout);
+    }
 
     @Override
     public String execute(String cmd, ResultListener lis) throws MikrotikApiException {


### PR DESCRIPTION
Added new execute function that takes a timeout as parameter in order to set the timeout for the connection when executing the command